### PR TITLE
Update dependencies for compatibility with nodejs-4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mlive",
-	"version": "0.0.0",
+	"version": "0.0.1",
 	"description": "Manta liveness tester",
 	"bin": {
 		"mlive": "bin/mlive"
@@ -16,11 +16,11 @@
 	"homepage": "https://github.com/joyent/manta-mlive",
 	"dependencies": {
 		"assert-plus": "0.1.5",
-		"bunyan": "1.2.3",
-		"extsprintf": "1.2.1",
-		"manta": "1.4.6",
-		"posix-getopt": "1.1.0",
-		"vasync": "1.6.2",
+		"bunyan": "1.5.1",
+		"extsprintf": "1.3.0",
+		"manta": "2.0.3",
+		"posix-getopt": "1.2.0",
+		"vasync": "1.6.3",
 		"verror": "1.6.0"
 	}
 }


### PR DESCRIPTION
The only major version change is in Manta, and it hasn't affected mlive. I've been using it for about 3 months with no problems.
